### PR TITLE
Fixed invalid reference to heuristicValue attribute in hhZero

### DIFF
--- a/src/heuristics/hhZero.cpp
+++ b/src/heuristics/hhZero.cpp
@@ -19,12 +19,12 @@ hhZero::~hhZero() {
 }
 
 void hhZero::setHeuristicValue(searchNode *n, searchNode *parent, int action) {
-	n->heuristicValue = 0;
+	n->heuristicValue[index] = 0;
 	n->goalReachable = true;
 }
 void hhZero::setHeuristicValue(searchNode *n, searchNode *parent, int absTask,
 		int method) {
-	n->heuristicValue = 0;
+	n->heuristicValue[index] = 0;
 	n->goalReachable = true;
 }
 


### PR DESCRIPTION
This is a tiny problem I found when running experiments with the naive Zero Heuristic that caused a segmentation fault. I assume that when this class was written you only used a single heuristic in the search procedure and then you refactored it. 